### PR TITLE
Fixed buffer overflow in swkbdDictWordCreate

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -59,17 +59,10 @@ typedef struct
 
 void swkbdDictWordCreate(dictWord *w, const char *read, const char *word)
 {
-    memset(w->read, 0, 0x32);
-    memset(w->word, 0, 0x32);
+    memset(w, 0, sizeof(*w));
 
-    uint16_t tmp[0x32 / sizeof(uint16_t)];
-    memset(tmp, 0, 0x32);
-
-    utf8_to_utf16(tmp, (uint8_t *)read, 0x19);
-    memcpy(w->read, tmp, 0x30);
-
-    utf8_to_utf16(tmp, (uint8_t *)word, 0x19);
-    memcpy(w->word, tmp, 0x30);
+    utf8_to_utf16(w->read, (uint8_t *)read, (sizeof(w->read) / sizeof(uint16_t)) - 1);
+    utf8_to_utf16(w->word, (uint8_t *)word, (sizeof(w->word) / sizeof(uint16_t)) - 1);
 }
 
 uint32_t replaceChar(uint32_t c)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -65,10 +65,10 @@ void swkbdDictWordCreate(dictWord *w, const char *read, const char *word)
     uint16_t tmp[0x32 / sizeof(uint16_t)];
     memset(tmp, 0, 0x32);
 
-    utf8_to_utf16(tmp, (uint8_t *)read, 0x30);
+    utf8_to_utf16(tmp, (uint8_t *)read, 0x19);
     memcpy(w->read, tmp, 0x30);
 
-    utf8_to_utf16(tmp, (uint8_t *)word, 0x30);
+    utf8_to_utf16(tmp, (uint8_t *)word, 0x19);
     memcpy(w->word, tmp, 0x30);
 }
 


### PR DESCRIPTION
Decreased the string length sent to `utf8_to_utf16` to prevent it from corrupting `dictwords`.
The 3rd argument of `utf8_to_utf16` is the length of the output array of `uint16_t` values not bytes.

Fixes https://github.com/J-D-K/JKSV/issues/114 where 'YYYY.DD.MM @ hh.mm.ss' date format would not show up in autocomplete.