### PR TITLE
Fix font services type for 16.0.0

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -52,7 +52,7 @@ static bool loadSystemFont()
     PlFontData shared[6];
     uint64_t langCode = 0;
 
-    if(R_FAILED(plInitialize(PlServiceType_System)))
+    if(R_FAILED(plInitialize(PlServiceType_User)))
         return false;
 
     if(FT_Init_FreeType(&lib))


### PR DESCRIPTION
JKSV uses pl:s right now for shared font, but pl:s no longer supports shared font commands on 16.0.0+.

This causes JKSV to data abort reading from NULL when trying to render the loading screen.

This PR fixes it by using the user-pl type, which is now the only way to use shared font commands.