### PR TITLE
fix: Google Drive Config Crash

### DIFF
--- a/inc/fs/dir.h
+++ b/inc/fs/dir.h
@@ -37,7 +37,7 @@ namespace fs
     {
         public:
             dirList() = default;
-            dirList(const std::string& _path);
+            dirList(const std::string& _path, bool ignoreDotFiles = false);
             void reassign(const std::string& _path);
             void rescan();
 

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -294,7 +294,7 @@ static void loadTitleDefs()
 
 static void loadDriveConfig()
 {
-    fs::dirList cfgList("/config/JKSV/");
+    fs::dirList cfgList("/config/JKSV/", true);
 
     std::string clientSecretPath;
     for(unsigned i = 0; i < cfgList.getCount(); i++)

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -309,15 +309,20 @@ static void loadDriveConfig()
 
     if(!clientSecretPath.empty())
     {
-        json_object *installed, *clientID, *clientSecret,*driveJSON = json_object_from_file(clientSecretPath.c_str());
-        json_object_object_get_ex(driveJSON, "installed", &installed);
-        json_object_object_get_ex(installed, "client_id", &clientID);
-        json_object_object_get_ex(installed, "client_secret", &clientSecret);
-
-        cfg::driveClientID = json_object_get_string(clientID);
-        cfg::driveClientSecret = json_object_get_string(clientSecret);
-
-        json_object_put(driveJSON);
+        json_object *installed, *clientID, *clientSecret, *driveJSON = json_object_from_file(clientSecretPath.c_str());
+        if (driveJSON) 
+        {
+            if(json_object_object_get_ex(driveJSON, "installed", &installed))
+            {
+                if(json_object_object_get_ex(installed, "client_id", &clientID) 
+                    && json_object_object_get_ex(installed, "client_secret", &clientSecret))
+                {
+                    cfg::driveClientID = json_object_get_string(clientID);
+                    cfg::driveClientSecret = json_object_get_string(clientSecret);
+                }
+            }
+            json_object_put(driveJSON);
+        }
     }
 }
 

--- a/src/fs/dir.cpp
+++ b/src/fs/dir.cpp
@@ -220,7 +220,7 @@ std::string fs::dirItem::getExt() const
     return util::getExtensionFromString(itm);
 }
 
-fs::dirList::dirList(const std::string& _path)
+fs::dirList::dirList(const std::string& _path, bool ignoreDotFiles)
 {
     DIR *d;
     struct dirent *ent;
@@ -228,7 +228,8 @@ fs::dirList::dirList(const std::string& _path)
     d = opendir(path.c_str());
 
     while((ent = readdir(d)))
-        item.emplace_back(path, ent->d_name);
+        if (!ignoreDotFiles || ent->d_name[0] != '.')
+            item.emplace_back(path, ent->d_name);
 
     closedir(d);
 


### PR DESCRIPTION
When reading the Google drive config ignore all files starting with a .

Fixes #204, #193 