### PR TITLE
Fix empty [R] name on certain webdav servers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ INCLUDES	:=	inc inc/ui inc/fs inc/gfx
 EXEFS_SRC	:=	exefs_src
 APP_TITLE   :=  JKSV
 APP_AUTHOR  :=  JK
-APP_VERSION :=  07.10.2023
+APP_VERSION :=  07.25.2024
 ROMFS	    :=	romfs
 ICON		:=	icon.jpg
 

--- a/inc/data.h
+++ b/inc/data.h
@@ -8,8 +8,8 @@
 #include "gfx.h"
 
 #define BLD_MON 07
-#define BLD_DAY 10
-#define BLD_YEAR 2023
+#define BLD_DAY 25
+#define BLD_YEAR 2024
 
 namespace data
 {

--- a/inc/webdav.h
+++ b/inc/webdav.h
@@ -48,5 +48,6 @@ namespace rfs {
         std::string getDirID(const std::string& dirName, const std::string& parentId);
 
         std::vector<RfsItem> getListWithParent(const std::string& _parent);
+        std::string getDisplayNameFromURL(const std::string &url);
     };
 }


### PR DESCRIPTION
Fixes #227 

```
commit 045ae7024e1c4dd1f5e6f80d08e39dab33b1fcb6 (HEAD -> bugfix/fix-no-itemname, origin/bugfix/fix-no-itemname)
Author: Martin Riedel <1713643+rado0x54@users.noreply.github.com>
Date:   Thu Jul 25 18:20:08 2024 -0400

    fix: Provide fallback for item.name from href if webdav server does not provide "displayname" property.
```