### PR TITLE
Fix: Only use safeTitle for remote directory name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ INCLUDES	:=	inc inc/ui inc/fs inc/gfx
 EXEFS_SRC	:=	exefs_src
 APP_TITLE   :=  JKSV
 APP_AUTHOR  :=  JK
-APP_VERSION :=  07.25.2024
+APP_VERSION :=  07.27.2024
 ROMFS	    :=	romfs
 ICON		:=	icon.jpg
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ INCLUDES	:=	inc inc/ui inc/fs inc/gfx
 EXEFS_SRC	:=	exefs_src
 APP_TITLE   :=  JKSV
 APP_AUTHOR  :=  JK
-APP_VERSION :=  07.10.2023
+APP_VERSION :=  07.25.2024
 ROMFS	    :=	romfs
 ICON		:=	icon.jpg
 

--- a/REMOTE_INSTRUCTIONS.MD
+++ b/REMOTE_INSTRUCTIONS.MD
@@ -1,4 +1,7 @@
 # Remote Storage
+
+⚠️ **WARNING** ⚠️: Breaking change with Version 07.27.2024. See [here](#remote-changelog)
+
 ## <a name="gdrive"></a><center> How to use Google Drive with JKSV </center>
 **USING GOOGLE DRIVE WITH JKSV CURRENTLY REQUIRES BUILDING IT YOURSELF. I AM VERY BUSY LATELY AND THINGS WILL ONLY GET FINISHED WHEN I HAVE TIME. Thanks, sorry for yelling.**
 
@@ -49,3 +52,7 @@
 2. Copy file to following folder on your card `SD:/config/JKSV/`
 3. The next time you start JKSV on your Switch, you should get a popup about the Webdav status
 4. If problems arise, check the log at `SD:/JKSV/log.txt`
+
+## Remote Changelog
+- **07.27.2024**: **Breaking Change**. "Unsafe" characters were removed from titlename on the remote directory. That means,
+  that if you had existing safes under a title with unsafe characters, you will need to move them manually.

--- a/inc/data.h
+++ b/inc/data.h
@@ -8,8 +8,8 @@
 #include "gfx.h"
 
 #define BLD_MON 07
-#define BLD_DAY 10
-#define BLD_YEAR 2023
+#define BLD_DAY 25
+#define BLD_YEAR 2024
 
 namespace data
 {

--- a/inc/data.h
+++ b/inc/data.h
@@ -8,7 +8,7 @@
 #include "gfx.h"
 
 #define BLD_MON 07
-#define BLD_DAY 25
+#define BLD_DAY 27
 #define BLD_YEAR 2024
 
 namespace data

--- a/inc/webdav.h
+++ b/inc/webdav.h
@@ -48,5 +48,6 @@ namespace rfs {
         std::string getDirID(const std::string& dirName, const std::string& parentId);
 
         std::vector<RfsItem> getListWithParent(const std::string& _parent);
+        std::string getDisplayNameFromURL(const std::string &url);
     };
 }

--- a/src/ui/fld.cpp
+++ b/src/ui/fld.cpp
@@ -317,10 +317,10 @@ void ui::fldPopulateMenu()
     unsigned fldInd = 1;
     if(fs::rfs)
     {
-        if(!fs::rfs->dirExists(t->title, fs::rfsRootID))
-            fs::rfs->createDir(t->title, fs::rfsRootID);
+        if(!fs::rfs->dirExists(t->safeTitle, fs::rfsRootID))
+            fs::rfs->createDir(t->safeTitle, fs::rfsRootID);
 
-        driveParent = fs::rfs->getDirID(t->title, fs::rfsRootID);
+        driveParent = fs::rfs->getDirID(t->safeTitle, fs::rfsRootID);
         driveFldList = fs::rfs->getListWithParent(driveParent);
 
         for(unsigned i = 0; i < driveFldList.size(); i++, fldInd++)


### PR DESCRIPTION
Contains #234.

Fixes #235.

```
Author: Martin Riedel <1713643+rado0x54@users.noreply.github.com>
Date:   Sat Jul 27 11:28:34 2024 -0400

    fix: use safeTitle instead of title for directory name on remote filesystem. This is a breaking change. Prior names with unsafe titlenames need to be moved manually.

```