### PR TITLE
add applet locking and main loop polling

### DIFF
--- a/Include/JKSV.hpp
+++ b/Include/JKSV.hpp
@@ -12,7 +12,7 @@ class JKSV
         // Exits JKSV
         ~JKSV();
         // Returns whether or not JKSV is actually running.
-        bool IsRunning(void) const;
+        bool IsRunning(void);
         // Updates input and back of state vector.
         void Update(void);
         // Renders base of app and states of vector.

--- a/Source/JKSV.cpp
+++ b/Source/JKSV.cpp
@@ -117,8 +117,11 @@ JKSV::~JKSV()
     FsLib::Exit();
 }
 
-bool JKSV::IsRunning(void) const
+bool JKSV::IsRunning(void)
 {
+    if (m_IsRunning) {
+        m_IsRunning = appletMainLoop();
+    }
     return m_IsRunning;
 }
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -13,3 +13,20 @@ int main(void)
     Config::Save();
     return 0;
 }
+
+extern "C" {
+
+// constructor thats called before main
+void userAppInit(void) {
+    Result rc;
+
+    if (R_FAILED(rc = appletLockExit()))
+        diagAbortWithResult(rc);
+}
+
+// destructor thats called after main
+void userAppExit(void) {
+    appletUnlockExit();
+}
+
+} // extern "C"


### PR DESCRIPTION
as explained in the gbatemp post.

---

`appletLockExit()` prevents the app from being closed via the home menu until either 15s has elapsed, or `appletUnlockExit()` is called.

`appletMainLoop()` will return false once the applet is being requested to exit, ie closing via the home menu.

so for example, a user attempts to close jksv via the home screen (or presses the home button whilst in applet mode), due to `appletLockExit()`, this prevents it from being killed immediately. `appletMainLoop()` will now return false, and so your main loop exits. after main returns, the function `userAppExit()` is called which in turn calls `appletUnlockExit()`, the app now closes.

this allows for all resources / files to be properly cleaned up, and any mid-transfer stuff to be handled as needed. there is a 15s window to do everything, which is *plenty* of time.