### PR TITLE
fix compatibility for uploading to some webdav providers

### DIFF
--- a/source/remote/WebDav.cpp
+++ b/source/remote/WebDav.cpp
@@ -143,6 +143,7 @@ bool remote::WebDav::upload_file(const fslib::Path &source, std::string_view rem
     curl::set_option(m_curl, CURLOPT_URL, url.get());
     curl::set_option(m_curl, CURLOPT_UPLOAD, 1L);
     curl::set_option(m_curl, CURLOPT_UPLOAD_BUFFERSIZE, Storage::SIZE_UPLOAD_BUFFER);
+    curl::set_option(m_curl, CURLOPT_INFILESIZE_LARGE, static_cast<curl_off_t>(sourceFile.get_size()));
     curl::set_option(m_curl, CURLOPT_READFUNCTION, curl::read_data_from_file);
     curl::set_option(m_curl, CURLOPT_READDATA, &uploadData);
 


### PR DESCRIPTION
Met the issue on some webdav providers using openresty, strangely they did not accept uploaded files from JKSV.

Then I used `--libcurl` on `curl` command line to analyze options, and did find that they've checked `CURLOPT_INFILESIZE_LARGE` as upload file size. Adding `CURLOPT_INFILESIZE_LARGE` resolved the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved WebDav file upload reliability by explicitly communicating the source file size information to the server before data transfer begins. This enhancement ensures proper handling of large file uploads, prevents potential transfer errors and compatibility issues, and provides the server with accurate size data needed for successful file transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->