### PR TITLE
Guard title sort against undecodable UTF-8 (BOTW 1.9.0 freeze)

### DIFF
--- a/source/data/User.cpp
+++ b/source/data/User.cpp
@@ -309,6 +309,7 @@ static bool sort_user_data(const data::UserDataEntry &entryA, const data::UserDa
                 uint32_t codepointB = 0;
                 ssize_t unitCountA  = decode_utf8(&codepointA, reinterpret_cast<const uint8_t *>(&titleA[i]));
                 ssize_t unitCountB  = decode_utf8(&codepointB, reinterpret_cast<const uint8_t *>(&titleB[j]));
+                if (unitCountA <= 0 || unitCountB <= 0) { return false; }
 
                 // Lower so case doesn't screw with it.
                 int charA = std::tolower(codepointA);


### PR DESCRIPTION
## Problem

JKSV freezes (then crashes) on The Legend of Zelda: Breath of the Wild 1.9.0 — #343, #355.

BOTW 1.9.0 ships the FW 21.0.0+ NACP format: when the `TitlesDataFormat` byte at NACP offset `0x3215` is 1, the language-entry block (`0x0–0x3000`) is deflate-compressed. libnx (including current master) does not decompress it (switchbrew/libnx#714), so `nacpGetLanguageEntry` returns a pointer into compressed garbage and the title string becomes random bytes.

Those garbage bytes then hit the alphabetical sort comparator in `sort_user_data`: `decode_utf8` returns a non-positive unit count for invalid sequences, the loop index never advances correctly, and JKSV locks up. The garbage title is also written into `cache.zip`, so the freeze survives relaunches.

## Fix

Bail out of the character-comparison loop as soon as either title yields an undecodable codepoint, instead of reading past it.

A companion PR fixes the matching infinite render loop in SDLLib: J-D-K/SDLLib#3.

## Notes

This makes affected titles load and sort safely, but their displayed names remain garbage until the compressed language block is actually decompressed (either in libnx or in JKSV). Happy to follow up with a decompression patch if you want it in JKSV itself.

Closes #343. Closes #355.
